### PR TITLE
Order transformation by uuid to make comparisons easier

### DIFF
--- a/mafia/src/main/java/au/org/emii/PostgresEditor.java
+++ b/mafia/src/main/java/au/org/emii/PostgresEditor.java
@@ -201,6 +201,7 @@ public class PostgresEditor {
             throw new Exception("Options should include one of -uuid or -all");
         }
 
+        query += " order by uuid";
 
         PreparedStatement stmt = conn.prepareStatement(query);
         ResultSet rs = stmt.executeQuery();


### PR DESCRIPTION
Allows an identity transform to be compared against a custom transform more easily as the order of the metadata records doesn't change.
